### PR TITLE
fix Alsa midi (broken by 16c798c)

### DIFF
--- a/source/imidi_alsa.cc
+++ b/source/imidi_alsa.cc
@@ -124,5 +124,7 @@ void Imidi_alsa::proc_midi (void)
                 ev.control.value = E->data.control.value;
                 break;
         }
+
+        proc_midi_event(ev);
     }
 }


### PR DESCRIPTION
Simple fix, missing line, Alsa midi now works again on Linux