### PR TITLE
fix bug introduced in Model::set_iflem by multistop changes (ed0e4f3)

### DIFF
--- a/source/model.cc
+++ b/source/model.cc
@@ -643,7 +643,7 @@ void Model::set_ifelm (int g, int i, int m)
               ++a;
             }
 #else
-            _qcomm->write (0, s ? I->_action0 : I->_action0);
+            _qcomm->write (0, s ? I->_action1 : I->_action0);
             _qcomm->write_commit (1);
             send_event (TO_IFACE, new M_ifc_ifelm (MT_IFC_ELCLR + s, g, i));
 #endif


### PR DESCRIPTION
typo caused set_ifelm not to work correctly